### PR TITLE
#50 Add a sentence to get_df that eliminates duplicate timestamps

### DIFF
--- a/mao_merge_45m/antenna_50_sps.py
+++ b/mao_merge_45m/antenna_50_sps.py
@@ -100,16 +100,23 @@ def get_df(
     index: int,
 ) -> pd.DataFrame:
     """Helper function."""
-    return pd.read_csv(
-        path_log,
-        sep="\s+",
-        header=None,
-        skiprows=lambda row: row % 10 != index,
-        parse_dates=[[1, 2]],
-        index_col="1_2",
-        usecols=range(1, 8),
-        date_parser=partial(pd.to_datetime, format=LOG_TIMEFMT),
-    ).astype(float)
+    return (
+        pd.read_csv(
+            path_log,
+            sep="\s+",
+            header=None,
+            skiprows=lambda row: row % 10 != index,
+            parse_dates=[[1, 2]],
+            index_col="1_2",
+            usecols=range(1, 8),
+            date_parser=partial(pd.to_datetime, format=LOG_TIMEFMT),
+        )
+        .astype(float)
+        .groupby(level=0)
+        .last()
+        .resample("100 ms")
+        .interpolate()
+    )
 
 
 def convert(


### PR DESCRIPTION
duplicate() function extracts duplicates of column data, not indexes.
In this case, groupby(level=0).last() is used to extract duplicate indexes. 